### PR TITLE
add simple set of goose load tests

### DIFF
--- a/loadtests/Cargo.toml
+++ b/loadtests/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+
+[package]
+name = "loadtest"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+goose = "^0.17"
+goose-eggs = "0.5.2"
+tokio = "1.38.0"
+reqwest = "0.11.27"
+log = "0.4"

--- a/loadtests/README.md
+++ b/loadtests/README.md
@@ -1,0 +1,31 @@
+# trustify loadtest
+
+A set of simple [goose](https://book.goose.rs/) load tests against the web and rest endpoints.
+
+## quickstart
+1. Ensure trustify is running.
+
+2. Install oidc-cli:
+```
+> cargo install oidc-cli
+```
+
+3. Set environment variables for OIDC authentication:
+```
+> export ISSUER_URL = "http://localhost:8090/realms/trustify"
+> export CLIENT_ID =  "testing-user"
+> export CLIENT_SECRET = "****************"
+```
+
+4. To load trustify endpoints with 3 concurrent users.
+```
+> cargo run --release --bin loadtest -- --host http://localhost:8080 -u 3
+```
+To stop load test hit [ctl-C], which should generate aggregate statistics.
+
+To load trustify endpoints against 10 concurrent users, generating an html report.
+```
+ cargo run --release -- --host http://localhost:8080  --report-file=report.html --no-reset-metrics -u 10
+```
+
+5. More goose run-time options [here](https://book.goose.rs/getting-started/runtime-options.html)

--- a/loadtests/src/main.rs
+++ b/loadtests/src/main.rs
@@ -1,0 +1,84 @@
+// The simplest loadtest example
+mod oidc;
+mod restapi;
+mod website;
+
+use crate::oidc::get_token;
+use crate::restapi::{
+    get_advisory, get_importer, get_oganizations, get_packages, get_products, get_sboms,
+    get_vulnerabilities, search_packages,
+};
+use crate::website::{
+    website_advisories, website_importers, website_index, website_openapi, website_packages,
+    website_sboms,
+};
+use goose::prelude::*;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), GooseError> {
+    GooseAttack::initialize()?
+        .register_scenario(
+            scenario!("WebsiteUser")
+                .set_weight(1)?
+                .register_transaction(transaction!(setup_custom_client).set_on_start())
+                // After each transactions runs, sleep randomly from 5 to 15 seconds.
+                .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?
+                .register_transaction(transaction!(website_index).set_name("/index"))
+                .register_transaction(transaction!(website_openapi).set_name("/openapi"))
+                .register_transaction(transaction!(website_sboms).set_name("/sboms"))
+                .register_transaction(transaction!(website_packages).set_name("/packages"))
+                .register_transaction(transaction!(website_advisories).set_name("/advisories"))
+                .register_transaction(transaction!(website_importers).set_name("/importers")),
+        )
+        .register_scenario(
+            scenario!("RestAPIUser")
+                .set_weight(1)?
+                .register_transaction(transaction!(setup_custom_client).set_on_start())
+                // After each transactions runs, sleep randomly from 5 to 15 seconds.
+                .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?
+                .register_transaction(
+                    transaction!(get_oganizations).set_name("/api/v1/organization"),
+                )
+                .register_transaction(transaction!(get_advisory).set_name("/api/v1/advisory"))
+                .register_transaction(transaction!(get_importer).set_name("/api/v1/importer"))
+                .register_transaction(transaction!(get_packages).set_name("/api/v1/purl"))
+                .register_transaction(transaction!(search_packages).set_name("/api/v1/purl?q=curl"))
+                .register_transaction(transaction!(get_products).set_name("/api/v1/product"))
+                .register_transaction(transaction!(get_sboms).set_name("/api/v1/sbom"))
+                .register_transaction(
+                    transaction!(get_vulnerabilities).set_name("/api/v1/vulnerability"),
+                ),
+        )
+        .execute()
+        .await?;
+
+    Ok(())
+}
+
+async fn setup_custom_client(user: &mut GooseUser) -> TransactionResult {
+    use reqwest::{header, Client};
+
+    let issuer_url: String = std::env::var("ISSUER_URL").unwrap();
+    let client_id: String = std::env::var("CLIENT_ID").unwrap();
+    let client_secret: String = std::env::var("CLIENT_SECRET").unwrap();
+
+    let auth_token: String = get_token(issuer_url, client_id, client_secret);
+    {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            header::HeaderValue::from_str(&auth_token).unwrap(),
+        );
+
+        // Build a custom client.
+        let builder = Client::builder()
+            .default_headers(headers)
+            .user_agent("loadtest-ua")
+            .timeout(Duration::from_secs(30));
+
+        // Assign the custom client to this GooseUser.
+        user.set_client_builder(builder).await?;
+        Ok(())
+    }
+}

--- a/loadtests/src/oidc.rs
+++ b/loadtests/src/oidc.rs
@@ -1,0 +1,42 @@
+// oidc-cli wrapper invoke
+use log::{info, warn};
+
+use std::process::Command;
+
+pub fn get_token(issuer_url: String, client_id: String, client_secret: String) -> String {
+    let create_client = Command::new("oidc")
+        .args([
+            "create",
+            "confidential",
+            "--force",
+            "testing-client",
+            "--issuer",
+            &issuer_url,
+            "--client-id",
+            &client_id,
+            "--client-secret",
+            &client_secret,
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    match create_client.status.code() {
+        Some(_value) => info!("Client created successfully"),
+        None => warn!("Error creating client: {}", create_client.status),
+    }
+
+    let fetch_token = Command::new("oidc")
+        .args(["token", "testing-client", "--bearer"])
+        .output()
+        .expect("Failed to execute command");
+
+    let mut auth_token: String = String::new();
+
+    if let Some(_) = fetch_token.status.code() {
+        auth_token = String::from_utf8_lossy(&fetch_token.stdout)
+            .to_string()
+            .replace(['\n', '\r'], "");
+    }
+
+    return auth_token;
+}

--- a/loadtests/src/restapi.rs
+++ b/loadtests/src/restapi.rs
@@ -1,0 +1,48 @@
+use goose::goose::{GooseUser, TransactionResult};
+
+pub async fn get_advisory(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/advisory").await?;
+
+    Ok(())
+}
+
+pub async fn get_importer(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/importer").await?;
+
+    Ok(())
+}
+
+pub async fn get_oganizations(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/organization").await?;
+
+    Ok(())
+}
+
+pub async fn get_packages(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/purl").await?;
+
+    Ok(())
+}
+
+pub async fn search_packages(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/purl?q=curl").await?;
+
+    Ok(())
+}
+
+pub async fn get_products(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/product").await?;
+
+    Ok(())
+}
+
+pub async fn get_sboms(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/sbom").await?;
+
+    Ok(())
+}
+pub async fn get_vulnerabilities(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/api/v1/vulnerability").await?;
+
+    Ok(())
+}

--- a/loadtests/src/website.rs
+++ b/loadtests/src/website.rs
@@ -1,0 +1,37 @@
+use goose::goose::{GooseUser, TransactionResult};
+
+pub async fn website_index(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("").await?;
+
+    Ok(())
+}
+
+pub async fn website_openapi(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/openapi").await?;
+
+    Ok(())
+}
+
+pub async fn website_sboms(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/sboms").await?;
+
+    Ok(())
+}
+
+pub async fn website_packages(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/packages").await?;
+
+    Ok(())
+}
+
+pub async fn website_advisories(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/advisories").await?;
+
+    Ok(())
+}
+
+pub async fn website_importers(user: &mut GooseUser) -> TransactionResult {
+    let _response = user.get("/importers").await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a standalone setset of [goose](https://book.goose.rs/) loadtests.

To setup check out README.md, to load trustify endpoints with 3 concurrent users.
```
> cargo run --bin loadtest -- --host http://localhost:8080 -u 3
```
To stop load test hit [ctl-C], which should generate aggregate statistics.

To load trustify endpoints against 10 concurrent users, generating an html report.
```
 cargo run --release -- --host http://localhost:8080  --report-file=report.html --no-reset-metrics -u 10
```

**Note** - opted to just wrap oidc-cli instead of pull over a lot of code ... also it was handy to be able to reuse oidc-cli client when encountering problems to manually test with auth token with curl.
