### PR TITLE
Add env vars to control http invoke wait times

### DIFF
--- a/loadtests/README.md
+++ b/loadtests/README.md
@@ -17,6 +17,14 @@ A set of simple [goose](https://book.goose.rs/) load tests against the web and r
 > export CLIENT_SECRET = "****************"
 ```
 
+To change wait times between http invokes set the following env vars:
+```bash
+> export WAIT_TIME_FROM = 1
+> export WAIT_TIME_TO =  2
+```
+
+Alternately, for no wait times between http invokes set these env vars to 0.
+
 4. To load trustify endpoints with 3 concurrent users.
 ```
 > cargo run --release --bin loadtest -- --host http://localhost:8080 -u 3

--- a/loadtests/src/main.rs
+++ b/loadtests/src/main.rs
@@ -19,17 +19,27 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), GooseError> {
+    let wait_time_from: u64 = std::env::var("WAIT_TIME_FROM")
+        .map(|s| s.parse().unwrap_or(5))
+        .unwrap_or(5);
+    let wait_time_to: u64 = std::env::var("WAIT_TIME_TO")
+        .map(|s| s.parse().unwrap_or(15))
+        .unwrap_or(15);
+
     GooseAttack::initialize()?
         .register_scenario(
             scenario!("WebsiteUser")
-                .set_weight(1)?
+                // .set_weight(1)?
                 .register_transaction(
                     transaction!(setup_custom_client)
                         .set_on_start()
                         .set_name("logon"),
                 )
                 // After each transactions runs, sleep randomly from 5 to 15 seconds.
-                .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?
+                .set_wait_time(
+                    Duration::from_secs(wait_time_from),
+                    Duration::from_secs(wait_time_to),
+                )?
                 .register_transaction(transaction!(website_index).set_name("/index"))
                 .register_transaction(transaction!(website_openapi).set_name("/openapi"))
                 .register_transaction(transaction!(website_sboms).set_name("/sboms"))
@@ -39,37 +49,43 @@ async fn main() -> Result<(), GooseError> {
         )
         .register_scenario(
             scenario!("RestAPIUser")
-                .set_weight(1)?
+                // .set_weight(1)?
                 .register_transaction(
                     transaction!(setup_custom_client)
                         .set_on_start()
                         .set_name("logon"),
                 )
                 // After each transactions runs, sleep randomly from 5 to 15 seconds.
-                .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?
+                .set_wait_time(
+                    Duration::from_secs(wait_time_from),
+                    Duration::from_secs(wait_time_to),
+                )?
                 .register_transaction(
                     transaction!(get_oganizations).set_name("/api/v1/organization"),
                 )
                 .register_transaction(transaction!(get_advisory).set_name("/api/v1/advisory"))
+                .register_transaction(
+                    transaction!(get_vulnerabilities).set_name("/api/v1/vulnerability"),
+                )
                 .register_transaction(transaction!(get_importer).set_name("/api/v1/importer"))
                 .register_transaction(transaction!(get_packages).set_name("/api/v1/purl"))
                 .register_transaction(transaction!(search_packages).set_name("/api/v1/purl?q=curl"))
                 .register_transaction(transaction!(get_products).set_name("/api/v1/product"))
-                .register_transaction(transaction!(get_sboms).set_name("/api/v1/sbom"))
-                .register_transaction(
-                    transaction!(get_vulnerabilities).set_name("/api/v1/vulnerability"),
-                ),
+                .register_transaction(transaction!(get_sboms).set_name("/api/v1/sbom")),
         )
         .register_scenario(
             scenario!("GraphQLUser")
-                .set_weight(1)?
+                // .set_weight(1)?
                 .register_transaction(
                     transaction!(setup_custom_client)
                         .set_on_start()
                         .set_name("logon"),
                 )
                 // After each transactions runs, sleep randomly from 5 to 15 seconds.
-                .set_wait_time(Duration::from_secs(5), Duration::from_secs(15))?
+                .set_wait_time(
+                    Duration::from_secs(wait_time_from),
+                    Duration::from_secs(wait_time_to),
+                )?
                 .register_transaction(
                     transaction!(graphql_query_advisory).set_name("query advisory with /graphql"),
                 ),


### PR DESCRIPTION
Wait control times are default 5-15 seconds ... to change set 

```
> export WAIT_TIME_FROM = 1
> export WAIT_TIME_TO =  2
```

For no wait times set these env vars to 0.