### PR TITLE
feat: allow using markdown and baseline reports

### DIFF
--- a/loadtests/.gitignore
+++ b/loadtests/.gitignore
@@ -1,0 +1,2 @@
+report.*
+baseline.json

--- a/loadtests/Cargo.toml
+++ b/loadtests/Cargo.toml
@@ -9,15 +9,17 @@ edition = "2021"
 anyhow = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env"] }
-goose = "^0.17"
-goose-eggs = "0.5.2"
+goose = "=0.17.3-dev"
+goose-eggs = "0.5.3-dev"
 humantime = "2"
 log = "0.4"
 openid = "0.14"
 reqwest = "0.12"
 tokio = { version = "1.38.0", features = ["sync"] }
 
-# goose still requires reqwest 0.11
-[dependencies.reqwest_0_11]
-version = "0.11.27"
-package = "reqwest"
+[patch.crates-io]
+#goose = { path = "../../goose" }
+#goose-eggs = { path = "../../goose-eggs" }
+
+goose = { git = "https://github.com/ctron/goose", branch = "feature/baseline_1" }
+goose-eggs = { git = "https://github.com/ctron/goose-eggs", branch = "feature/uptick_deps_1" }

--- a/loadtests/src/main.rs
+++ b/loadtests/src/main.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), GooseError> {
 }
 
 async fn setup_custom_client(user: &mut GooseUser) -> TransactionResult {
-    use reqwest_0_11::{header, Client};
+    use reqwest::{header, Client};
 
     let issuer_url = std::env::var("ISSUER_URL").unwrap();
     let client_id = std::env::var("CLIENT_ID").unwrap();


### PR DESCRIPTION
This switches to a patched version of goose and goose-eggs which support json and markdown reports, and allow generating delta information from a baseline file.