### PR TITLE
fix: changes from post to get

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 openid = "0.14"
 reqwest = "0.12"
 tokio = { version = "1.38.0", features = ["sync"] }
+urlencoding = "2"
 
 [patch.crates-io]
 #goose = { path = "../../goose" }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,8 +1,10 @@
 use goose::goose::{GooseUser, TransactionResult};
+use urlencoding::encode;
 
 pub async fn graphql_query_advisory(user: &mut GooseUser) -> TransactionResult {
-    let body = r#"{"query": "{getAdvisories { id sha256 published organization { id website } vulnerabilities { id title }}}" }"#;
-    let _response = user.post("/graphql", body).await?;
-
+    let query = r#"{"query": "{getAdvisories { id sha256 published organization { id website } vulnerabilities { id title }}}" }"#;
+    let encoded_query = encode(query);
+    let url = format!("/graphql?query={}", encoded_query);
+    let _response = user.get(&url).await?;
     Ok(())
 }


### PR DESCRIPTION
* Currently graphql endpoints accepts only GET method

Closes #29 

it works at least:
```
2024-10-08T13:55:04.185054Z  INFO ThreadId(24) actix_web::middleware::logger: ::1 "GET /graphql?query=%7B%22query%22%3A%20%22%7BgetAdvisories%20%7B%20id%20sha256%20published%20organization%20%7B%20id%20website%20%7D%20vulnerabilities%20%7B%20id%20title%20%7D%7D%7D%22%20%7D HTTP/1.1" 200 687 "-" "goose/0.17.3-dev" 0.005461
2024-10-08T13:55:11.331627Z  INFO ThreadId(25) actix_web::middleware::logger: ::1 "GET /graphql?query=%7B%22query%22%3A%20%22%7BgetAdvisories%20%7B%20id%20sha256%20published%20organization%20%7B%20id%20website%20%7D%20vulnerabilities%20%7B%20id%20title%20%7D%7D%7D%22%20%7D HTTP/1.1" 200 687 "-" "goose/0.17.3-dev" 0.005915
2024-10-08T13:55:18.490982Z  INFO ThreadId(26) actix_web::middleware::logger: ::1 "GET /graphql?query=%7B%22query%22%3A%20%22%7BgetAdvisories%20%7B%20id%20sha256%20published%20organization%20%7B%20id%20website%20%7D%20vulnerabilities%20%7B%20id%20title%20%7D%7D%7D%22%20%7D HTTP/1.1" 200 687 "-" "goose/0.17.3-dev" 0.005733
2024-10-08T13:55:22.442870Z  INFO ThreadId(27) actix_web::middleware::logger: ::1 "GET /graphql?query=%7B%22query%22%3A%20%22%7BgetAdvisories%20%7B%20id%20sha256%20published%20organization%20%7B%20id%20website%20%7D%20vulnerabilities%20%7B%20id%20title%20%7D%7D%7D%22%20%7D HTTP/1.1" 200 687 "-" "goose/0.17.3-dev" 0.005442
```