### PR TITLE
feat: move slow tests into a new scenario

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,28 +107,30 @@ async fn main() -> Result<(), anyhow::Error> {
             .register_transaction(tx!(website_importers))
         })
         .register_scenario({
-            let mut s =
-                create_scenario("RestAPIUser", wait_time_from, wait_time_to, custom_client)?
-                    .register_transaction(tx!(list_organizations))
-                    .register_transaction(tx!(list_advisory))
-                    .register_transaction(tx!(list_advisory_paginated))
-                    .register_transaction(tx!(get_advisory_by_doc_id))
-                    .register_transaction(tx!(search_advisory))
-                    .register_transaction(tx!(list_vulnerabilities))
-                    .register_transaction(tx!(list_vulnerabilities_paginated))
-                    .register_transaction(tx!(list_importer))
-                    .register_transaction(tx!(list_packages))
-                    .register_transaction(tx!(list_packages_paginated))
-                    .register_transaction(tx!(search_purls))
-                    .register_transaction(tx!(search_exact_purl))
-                    .register_transaction(tx!(list_products))
-                    .register_transaction(tx!(list_sboms))
-                    .register_transaction(tx!(list_sboms_paginated))
-                    .register_transaction(tx!(get_analysis_status))
-                    .register_transaction(tx!(get_analysis_latest_cpe))
-                    .register_transaction(tx!(search_licenses))
-                    .register_transaction(tx!(search_sboms_by_license))
-                    .register_transaction(tx!(search_purls_by_license));
+            let mut s = create_scenario(
+                "RestAPIUser",
+                wait_time_from,
+                wait_time_to,
+                custom_client.clone(),
+            )?
+            .set_weight(5)?
+            .register_transaction(tx!(list_organizations))
+            .register_transaction(tx!(list_advisory))
+            .register_transaction(tx!(list_advisory_paginated))
+            .register_transaction(tx!(get_advisory_by_doc_id))
+            .register_transaction(tx!(search_advisory))
+            .register_transaction(tx!(list_vulnerabilities))
+            .register_transaction(tx!(list_vulnerabilities_paginated))
+            .register_transaction(tx!(list_importer))
+            .register_transaction(tx!(list_packages))
+            .register_transaction(tx!(list_packages_paginated))
+            .register_transaction(tx!(search_purls))
+            .register_transaction(tx!(search_exact_purl))
+            .register_transaction(tx!(list_products))
+            .register_transaction(tx!(list_sboms))
+            .register_transaction(tx!(list_sboms_paginated))
+            .register_transaction(tx!(get_analysis_status))
+            .register_transaction(tx!(get_analysis_latest_cpe));
 
             tx!(s.get_sbom?(scenario.get_sbom.clone()));
             tx!(s.get_sbom_advisories?(scenario.get_sbom_advisories.clone()));
@@ -141,6 +143,18 @@ async fn main() -> Result<(), anyhow::Error> {
             tx!(s.get_purl_details?(scenario.get_purl_details.clone()));
 
             s
+        })
+        .register_scenario({
+            create_scenario(
+                "RestAPIUserSlow",
+                wait_time_from,
+                wait_time_to,
+                custom_client,
+            )?
+            .set_weight(1)?
+            .register_transaction(tx!(search_licenses))
+            .register_transaction(tx!(search_sboms_by_license))
+            .register_transaction(tx!(search_purls_by_license))
         })
         // .register_scenario(
         //     scenario!("GraphQLUser")


### PR DESCRIPTION
Created a separate test scenario called `RestAPIUserSlow` to isolate slow-running license-related tests from the main REST API test suite.

Specific Changes

  1. Moved three license tests from `RestAPIUser` scenario to the new `RestAPIUserSlow` scenario:
    - `search_licenses`
    - `search_sboms_by_license`
    - `search_purls_by_license`
  2. Added scenario weights to control test distribution:
    - `RestAPIUser`: weight = 5 (runs more frequently)
    - `RestAPIUserSlow`: weight = 1 (runs less frequently)

This separation allows the load test to assign the slower license-related endpoints less frequently (1/6th as often) to users compared to the faster REST API endpoints, preventing these slow tests from bottlenecking the overall test performance while still including them in the test suite.

Locally tests using the current single-scenario setup as the baseline I got a consistent increase in the "standard" endpoint testing while still having the slow endpoints checked:
<img width="1022" height="943" alt="Screenshot 2025-10-20 at 11 22 48" src="https://github.com/user-attachments/assets/4ac233a5-764a-4b2e-9f36-560f8b92da22" />

