### PR TITLE
chore: update rust to 1.91.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.91.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
* Syncs with trustify rust version and this version uses llvm 21 which they say that it has perf improvements https://releases.rs/docs/1.91.0/#internal-changes